### PR TITLE
EVNT-38: Add test-hibernate.cfg.xml for Spring tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
- - oraclejdk8
+ - openjdk8

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -18,6 +18,7 @@
 		<property name="configLocations">
 			<list>
 				<value>classpath:hibernate.cfg.xml</value>
+                <value>classpath:test-hibernate.cfg.xml</value>
 			</list>
 		</property>
 		<property name="mappingJarLocations">

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory/>
+</hibernate-configuration>


### PR DESCRIPTION
Link to talk :- https://talk.openmrs.org/t/sessionfactory-bean-definition-ignores-test-hibernate-cfg-xml-in-event-api-tests-jar/25813

Link to card :- https://issues.openmrs.org/browse/EVNT-38.
