### PR TITLE
EVNT-47: Failed JavaDoc generation to not fail releases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,16 @@
 						<arguments>-DskipTests -Dmaven.javadoc.skip=true</arguments>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.6.3</version>
+					<configuration>
+						<additionalJOptions>
+							<additionalJOption>-Xdoclint:none</additionalJOption>
+						</additionalJOptions>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
This is related to [this PR](https://github.com/openmrs/openmrs-module-event/pull/17), which uncovered that _'Javadoc generation'_ can still cause release failures, even when it’s implicitly skipped by the release plugin.

Ticket: https://openmrs.atlassian.net/browse/EVNT-47